### PR TITLE
files-test.md + teste

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -34,7 +34,7 @@ function exibirLinks(links) {
     console.log(
       `href: ${link.href}\n` +
       `text: ${link.text}\n` +
-      `file: ${link.file}\n` +
+      `files: ${link.arquivo}\n` +
       `${informacoesStatus}\n`
     );
   });

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ function encontrarLinksETexto(dados, arquivo) {
   return correspondencias.map((correspondencia) => ({
     href: correspondencia.replace(regex, '$2').trim(),
     text: correspondencia.replace(regex, '$1').trim(),
-    arquivo,
+    arquivo: arquivo
   }));
 }
 

--- a/test/files-test.md
+++ b/test/files-test.md
@@ -1,0 +1,6 @@
+## [Investing ](https://www.investing.com/economic-calendar/)
+
+## [InfoMoney ](https://www.infomoney.com.br/)
+
+## [google](https://www.google.com.br/)
+

--- a/test/md-links.spec.js
+++ b/test/md-links.spec.js
@@ -1,33 +1,76 @@
-const fs = require('fs').promises;
-const { encontrarLinksETexto } = require('../src/index.js');
+const { encontrarLinksETexto, obterLinksDoArquivoMd, mdLinks } = require('../src/index.js');
+const fs = require('fs');
 
-describe('Testes para funções de extração de links', () => {
-  test('encontrarLinksETexto retorna os links e textos corretos', () => {
-    const dados = `
-    [Investing](https://www.investing.com/economic-calendar/)
-    [InfoMoney](https://www.infomoney.com.br/)
-    [google](https://www.google.com.br/)
-    `;
-    const arquivo = 'files.md';
-    const resultado = encontrarLinksETexto(dados, arquivo);
 
+test('encontrarLinksETexto lê o conteúdo de um arquivo .md e retorna os links', () => {
+  const arquivo = 'test/files-test.md';
+  const dados = fs.readFileSync(arquivo, 'utf-8');
+
+  const resultado = encontrarLinksETexto(dados, arquivo);
+
+  expect(resultado).toEqual([
+    {
+      href: 'https://www.investing.com/economic-calendar/',
+      text: 'Investing',
+      arquivo: arquivo,
+    },
+    {
+      href: 'https://www.infomoney.com.br/',
+      text: 'InfoMoney',
+      arquivo: arquivo,
+    },
+    {
+      href: 'https://www.google.com.br/',
+      text: 'google',
+      arquivo: arquivo,
+    },
+  ]);
+});
+
+test('obterLinksDoArquivoMd retorna os links corretos do arquivo', () => {
+  const arquivo = 'test/files-test.md';
+
+  return obterLinksDoArquivoMd(arquivo).then(resultado => {
     expect(resultado).toEqual([
       {
         href: 'https://www.investing.com/economic-calendar/',
         text: 'Investing',
-      
+        arquivo,
       },
       {
         href: 'https://www.infomoney.com.br/',
         text: 'InfoMoney',
-      
+        arquivo,
       },
       {
         href: 'https://www.google.com.br/',
         text: 'google',
-       
+        arquivo,
       },
     ]);
   });
+});
 
- 
+test('mdLinks retorna um array de links e caminho completo dos arquivos ', () => {
+  const caminho = './test';
+
+  return mdLinks(caminho).then((arraysDeLinks) => {
+    expect(arraysDeLinks).toEqual([
+      {
+        href: 'https://www.investing.com/economic-calendar/',
+        text: 'Investing',
+        arquivo: 'C:\\Users\\user\\Documents\\GitHub\\SAP010-md-links\\test\\files-test.md',
+      },
+      {
+        href: 'https://www.infomoney.com.br/',
+        text: 'InfoMoney',
+        arquivo: 'C:\\Users\\user\\Documents\\GitHub\\SAP010-md-links\\test\\files-test.md',
+      },
+      {
+        href: 'https://www.google.com.br/',
+        text: 'google',
+        arquivo: 'C:\\Users\\user\\Documents\\GitHub\\SAP010-md-links\\test\\files-test.md',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Seguindo as orientações do teste camp, foi criada uma pasta dedicada para armazenar os links de teste + a implementação do  caminho relativo.